### PR TITLE
Check global is array before reading its values

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -25,7 +25,7 @@ function domainlimit_link_filter( $original_return, $url, $keyword = '', $title 
 
 	// If the user is exempt, don't even bother checking.
 	global $domainlimit_exempt_users;
-	if ( in_array( YOURLS_USER, $domainlimit_exempt_users ) ) {
+	if ( is_array( $domainlimit_exempt_users ) && in_array( YOURLS_USER, $domainlimit_exempt_users ) ) {
 		return $original_return;
 	}
 


### PR DESCRIPTION
Using `in_array` on a `null` value will return an Exception with PHP8 and later.

```
<b>Fatal error</b>:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /var/www/html/user/plugins/yourls-domainlimit-plugin/plugin.php:28
```

This MR extends the condition to start by checking the global variable actually is an array before even trying to look for a value in it.