### PR TITLE
Replace deprecated yourls_escape call

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -34,8 +34,7 @@ function domainlimit_link_filter( $original_return, $url, $keyword = '', $title 
 
 	// The plugin hook gives us the raw URL input by the user, but
 	// it needs some cleanup before it's suitable for parse_url().
-	$url = yourls_encodeURI( $url );
-	$url = yourls_escape( yourls_sanitize_url( $url) );
+	$url = yourls_sanitize_url( $url );
 	if ( !$url || $url == 'http://' || $url == 'https://' ) {
 		$return['status']    = 'fail';
 		$return['code']      = 'error:nourl';


### PR DESCRIPTION
Fixes https://github.com/nicwaller/yourls-domainlimit-plugin/issues/6

`yourls_escape` has been deprecated since YOURLS `1.7.3`, and was always meant to escape values before they are inserted in the database.

As far as I could tell, calling `yourls_sanitize_url` should be sufficient, since it calls `yourls_esc_url`, which itself calls `yourls_normalize_uri`.

`yourls_encodeURI` is also deprecated since `1.9.1`