### PR TITLE
Compatibility fixes for PHP 8 and YOURLS 1.9.2

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -25,8 +25,10 @@ function domainlimit_link_filter( $original_return, $url, $keyword = '', $title 
 
 	// If the user is exempt, don't even bother checking.
 	global $domainlimit_exempt_users;
-	if ( in_array( YOURLS_USER, $domainlimit_exempt_users ) ) {
-		return $original_return;
+	if ( defined( 'YOURLS_USER' ) && is_array( $domainlimit_exempt_users ) ) {
+		if ( in_array( YOURLS_USER, $domainlimit_exempt_users ) ) {
+			return $original_return;
+		}
 	}
 
 	global $domainlimit_list;

--- a/plugin.php
+++ b/plugin.php
@@ -36,8 +36,7 @@ function domainlimit_link_filter( $original_return, $url, $keyword = '', $title 
 
 	// The plugin hook gives us the raw URL input by the user, but
 	// it needs some cleanup before it's suitable for parse_url().
-	$url = yourls_encodeURI( $url );
-	$url = yourls_escape( yourls_sanitize_url( $url) );
+	$url = yourls_sanitize_url_safe( $url );
 	if ( !$url || $url == 'http://' || $url == 'https://' ) {
 		$return['status']    = 'fail';
 		$return['code']      = 'error:nourl';

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Domain Limiter
 Plugin URI: https://github.com/nicwaller/yourls-domainlimit-plugin
 Description: Only allow URLs from admin-specified domains
-Version: 1.1.0
+Version: 1.1.1
 Author: nicwaller
 Author URI: https://github.com/nicwaller
 */


### PR DESCRIPTION
## What

Introduce a few small but essential fixes for compatibility with PHP 8 and YOURLS 1.9.2

- check if constant `YOURLS_USER` is defined before using it
   - Starting with PHP 8, using undefined constants is now a fatal error
   - This again allows the plugin to be used when YOURLS has public shortening enabled
- check if global `domainlimit_exempt_users` is an array before using it
   - This avoids a fatal error when `$domainlimit_exempt_users` is not set in config.php
- remove use of deprecated function `yourls_encodeURI()`
   - `yourls_encodeURI` has been deprecated since 1.9.1
- remove use of deprecated function `yourls_escape()`
   - `yourls_escape` has been deprecated since 1.7.3
   - Use [`yourls_sanitize_url_safe`](https://github.com/YOURLS/YOURLS/blob/b493c47e6f02a7655d388b271b042e1869bfc3e8/includes/functions-formatting.php#L127-L144) instead

This fixes #6

## Testing

I added a unit test suite in #11 that gets run with GitHub Actions.  The test suite is now passing. ✅

I also completed end-to-end integration testing with these software versions:

- YOURLS/1.9.2
- PHP/8.2
- Apache/2.4.57
- MySQL/8.3

## Credit

This combines suggested improvements from:

- #7
- #8
- #9